### PR TITLE
Update Rhasspy to 2.5.8 (Dockerfile)

### DIFF
--- a/rhasspy/Dockerfile
+++ b/rhasspy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhasspy/rhasspy:2.5.7
+FROM rhasspy/rhasspy:2.5.8
 LABEL maintainer="Michael Hansen <mike@rhasspy.org>"
 
 ENV LANG C.UTF-8


### PR DESCRIPTION
With https://github.com/rhasspy/hassio-addons/commit/b1230135da6ac2999e23fd9abd88f3a171350ea8 you updated the versions in `config.json` and  the changelog. The `Dockerfile` though still refers to 2.5.7.