### PR TITLE
Add CI addon config lint

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "06:00"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,16 @@
+name: Lint
+on: [push, pull_request]
+jobs:
+  build:
+    name: Add-on configuration
+    runs-on: ubuntu-latest
+    strategy:
+       matrix:
+         channel: [rhasspy, voice-de-thorsten, voice-es-css10, voice-fr-siwis, voice-nl-rdh, voice-ru-nikolaev]
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v2
+      - name: 🚀 Run Home Assistant Add-on Lint on ${{ matrix.channel }}
+        uses: frenck/action-addon-linter@v2
+        with:
+          path: "./${{ matrix.channel }}"

--- a/rhasspy/config.json
+++ b/rhasspy/config.json
@@ -4,13 +4,11 @@
     "version": "2.5.9",
     "description": "Offline voice assistant for Home Assistant",
     "url": "https://github.com/rhasspy/hassio-addons/tree/master/rhasspy",
-    "startup": "application",
     "arch": [
         "aarch64",
         "amd64",
         "armhf"
     ],
-    "boot": "auto",
     "map": [
         "share:rw",
         "ssl"

--- a/voice-de-thorsten/config.json
+++ b/voice-de-thorsten/config.json
@@ -4,15 +4,11 @@
     "version": "1.0.1",
     "description": "German text to speech voice",
     "url": "https://github.com/rhasspy/hassio-addons/tree/master/voice-de-thorsten",
-    "startup": "application",
     "arch": [
         "aarch64",
         "amd64",
         "armhf"
     ],
-    "boot": "auto",
-    "options": {},
-    "schema": {},
     "ports": {
         "5002/tcp": 59125
     },

--- a/voice-es-css10/config.json
+++ b/voice-es-css10/config.json
@@ -4,15 +4,11 @@
     "version": "1.0.1",
     "description": "Spanish text to speech voice",
     "url": "https://github.com/rhasspy/hassio-addons/tree/master/voice-es-css10",
-    "startup": "application",
     "arch": [
         "aarch64",
         "amd64",
         "armhf"
     ],
-    "boot": "auto",
-    "options": {},
-    "schema": {},
     "ports": {
         "5002/tcp": 59125
     },

--- a/voice-fr-siwis/config.json
+++ b/voice-fr-siwis/config.json
@@ -4,15 +4,11 @@
     "version": "1.0.1",
     "description": "French text to speech voice",
     "url": "https://github.com/rhasspy/hassio-addons/tree/master/voice-fr-siwis",
-    "startup": "application",
     "arch": [
         "aarch64",
         "amd64",
         "armhf"
     ],
-    "boot": "auto",
-    "options": {},
-    "schema": {},
     "ports": {
         "5002/tcp": 59125
     },

--- a/voice-nl-rdh/config.json
+++ b/voice-nl-rdh/config.json
@@ -4,15 +4,11 @@
     "version": "1.0.3",
     "description": "Dutch text to speech voice",
     "url": "https://github.com/rhasspy/hassio-addons/tree/master/voice-nl-rdh",
-    "startup": "application",
     "arch": [
         "aarch64",
         "amd64",
         "armhf"
     ],
-    "boot": "auto",
-    "options": {},
-    "schema": {},
     "ports": {
         "5002/tcp": 59125
     },

--- a/voice-ru-nikolaev/config.json
+++ b/voice-ru-nikolaev/config.json
@@ -4,15 +4,11 @@
     "version": "1.0.1",
     "description": "Russian text to speech voice",
     "url": "https://github.com/rhasspy/hassio-addons/tree/master/voice-ru-nikolaev",
-    "startup": "application",
     "arch": [
         "aarch64",
         "amd64",
         "armhf"
     ],
-    "boot": "auto",
-    "options": {},
-    "schema": {},
     "ports": {
         "5002/tcp": 59125
     },


### PR DESCRIPTION
Frenck wrote a little Github action, that lints the config file of addons:
https://github.com/frenck/action-addon-linter

This PR implements that linter via Github CI and also removes one parameter, that had the default value (according to the linter) and could therefore be removed.

The result for the first run of the CI (which fails, because of parameters with default values) can be seen here:
https://github.com/TheZoker/hassio-addons/actions/runs/549081705\

And a successful run (after cleaning the default values) here:
https://github.com/TheZoker/hassio-addons/actions/runs/549094455