### PR TITLE
Config improvements

### DIFF
--- a/rhasspy/CHANGELOG.md
+++ b/rhasspy/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [?] - ?
+
+### Added
+
+- Home Assistant automatic authorization
+- Add-on options descriptions (English only for now)
+
+### Changed
+
+- Make most of the configuration optional
+- Change the asoundrc option to be an array (one entry - one line in the resulting asoundrc)
+
 ## [2.5.10] - 2020 Apr 10
 
 ### Added
@@ -8,7 +20,7 @@
 - Minimum ASR confidence threshold for dialogue manager
 - Detect AVX support and warn for Larynx, DeepSpeech, and Precise in Web UI
 - Handle spaces in converter arguments with word!(converter, ...)
-- rhasspy-tts-cli-hermes TTS commands may be Jinja2 templates (--use-jinja2)
+- rhasspy-tts-cli-hermes TTS commands may be Jinja2 templates (`--use-jinja2`)
 - Support for MaryTTS effects (jasonhildebrand)
 - customData added to hermes/nlu/query message
 - customData is copied by NLU services from query to intent/intentNotRecognized
@@ -49,7 +61,7 @@
 - Reboot/shutdown menu in web UI
 - Add text to speech testing tools in settings page
 - Make it clearer in web UI when restarts are required
-- _site_id meta slot to Home Assistant intents/events (bk90)
+- \_site_id meta slot to Home Assistant intents/events (bk90)
 
 ### Fixed
 

--- a/rhasspy/Dockerfile
+++ b/rhasspy/Dockerfile
@@ -1,4 +1,6 @@
-FROM rhasspy/rhasspy:2.5.10
+ARG BUILD_FROM
+FROM $BUILD_FROM
+
 LABEL maintainer="Michael Hansen <mike@rhasspy.org>"
 
 ENV LANG C.UTF-8

--- a/rhasspy/build.json
+++ b/rhasspy/build.json
@@ -1,0 +1,7 @@
+{
+    "build_from": {
+        "aarch64": "rhasspy/rhasspy:2.5.10",
+        "amd64": "rhasspy/rhasspy:2.5.10",
+        "armhf": "rhasspy/rhasspy:2.5.10"
+    }
+}

--- a/rhasspy/config.json
+++ b/rhasspy/config.json
@@ -14,13 +14,7 @@
         "ssl"
     ],
     "options": {
-        "profile_dir": "/share/rhasspy/profiles",
-        "profile_name": "en",
-        "ssl": false,
-        "certfile": "cert",
-        "keyfile": "key",
-        "asoundrc": "",
-        "http_root": ""
+        "profile_name": "en"
     },
     "audio": true,
     "ports": {
@@ -32,13 +26,13 @@
         "12333/udp": "Port for HTTP POST audio stream input"
     },
     "schema": {
-        "profile_dir": "str",
         "profile_name": "str",
-        "ssl": "bool",
-        "certfile": "match(^[^/].*)",
-        "keyfile": "match(^[^/].*)",
-        "asoundrc": "str",
-        "http_root": "str"
+        "profile_dir": "str?",
+        "ssl": "bool?",
+        "certfile": "match(^[^/].*)?",
+        "keyfile": "match(^[^/].*)?",
+        "http_root": "str?",
+        "asoundrc": ["str?"]
     },
     "homeassistant_api": true,
     "webui": "[PROTO:ssl]://[HOST]:[PORT:12101]/"

--- a/rhasspy/run.sh
+++ b/rhasspy/run.sh
@@ -33,6 +33,14 @@ if [[ -f "${CONFIG_PATH}" ]]; then
     fi
 fi
 
+if [[ ! -z "${SUPERVISOR_TOKEN}" ]]; then
+    # Configure Home Assistant connection
+    jq --raw-input \
+        '.home_assistant += {"access_token": "${SUPERVISOR_TOKEN}", "url": "http://supervisor/core"}' \
+        "${CONFIG_PATH}" > /tmp/profile.json
+    mv /tmp/profile.json "${CONFIG_PATH}"
+fi
+
 if [[ -z "${RHASSPY_ARGS[*]}" ]]; then
     /usr/lib/rhasspy/bin/rhasspy-voltron "$@"
 else

--- a/rhasspy/run.sh
+++ b/rhasspy/run.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/env bash
 
+set -e
+
 if [[ -f "${CONFIG_PATH}" ]]; then
     # Hass.IO configuration
     profile_name="$(jq --raw-output '.profile_name' "${CONFIG_PATH}")"
+    if [[ -z "${profile_name}" ]]; then
+        echo "No profile name provided!" 1>&2
+        exit 1
+
     profile_dir="$(jq --raw-output '.profile_dir' "${CONFIG_PATH}")"
+    if [[ -z "${profile_dir}" ]]; then
+        profile_dir='/share/rhasspy/profiles'
+    fi
     RHASSPY_ARGS=('--profile' "${profile_name}" '--user-profiles' "${profile_dir}")
 
     # Copy user-defined asoundrc to root
-    asoundrc="$(jq --raw-output '.asoundrc' "${CONFIG_PATH}")"
+    asoundrc="$(jq --raw-output '.asoundrc[]' "${CONFIG_PATH}")"
     if [[ ! -z "${asoundrc}" ]]; then
-	    echo "${asoundrc}" > /root/.asoundrc
+        echo "${asoundrc}" > /root/.asoundrc
     fi
 
     # Add SSL settings

--- a/rhasspy/run.sh
+++ b/rhasspy/run.sh
@@ -31,14 +31,14 @@ if [[ -f "${CONFIG_PATH}" ]]; then
     if [[ ! -z "${http_root}" ]]; then
         RHASSPY_ARGS+=('--http-root' "${http_root}")
     fi
-fi
 
-if [[ ! -z "${SUPERVISOR_TOKEN}" ]]; then
-    # Configure Home Assistant connection
-    jq --raw-input \
-        '.home_assistant += {"access_token": "${SUPERVISOR_TOKEN}", "url": "http://supervisor/core"}' \
-        "${CONFIG_PATH}" > /tmp/profile.json
-    mv /tmp/profile.json "${CONFIG_PATH}"
+    if [[ ! -z "${SUPERVISOR_TOKEN}" ]]; then
+        # Auto-configure Home Assistant connection
+        PROFILE_PATH="${profile_dir}/${profile_name}/profile.json"
+        jq \
+            '.home_assistant |= {"access_token": "'"${SUPERVISOR_TOKEN}"'", "url": "http://supervisor/core"}' \
+            "${PROFILE_PATH}"
+    fi
 fi
 
 if [[ -z "${RHASSPY_ARGS[*]}" ]]; then

--- a/rhasspy/translations/en.yaml
+++ b/rhasspy/translations/en.yaml
@@ -1,0 +1,34 @@
+---
+configuration:
+  profile_name:
+    name: Profile name
+    description: >-
+      Name of the profile to use, aka a 2-letter language code.
+      See https://rhasspy.readthedocs.io/en/latest/#supported-languages for an up-to-date list.
+  profile_dir:
+    name: Profile directory
+    description: >-
+      Directory, in which the profile will be stored.
+      If empty defauls to `/share/rhasspy/profiles`.
+  ssl:
+    name: SSL (HTTPS) toggle
+    description: >-
+      Whether to enable accessing Rhasspy's web interface via HTTPS.
+      Requires certfile and keyfile to be provided (can be self-signed).
+      See https://rhasspy.readthedocs.io/en/latest/usage/#secure-hosting-with-https for details.
+      If empty defaults to false.
+  certfile:
+    name: SSL certificate file
+    description: Certificate file for serving the web interface via HTTPS. See `ssl` description.
+  keyfile:
+    name: SSL key file
+    description: Key file for serving the web interface via HTTPS. See `ssl` description.
+  http_root:
+    name: HTTP root
+    description: >-
+      URL root for web server, i.e. the web interface will be available under `http://[hass-host]:[rhasspy-port]/<http_root>/`.
+  asoundrc:
+    name: Asoundrc configuration
+    description: >-
+      An asoundrc configuration to be used in the container.
+      Note that, by default, Home Assistant automatically provides a PulseAudio-mapped device to all the audio-enabled plugins.


### PR DESCRIPTION
This PR adds minor UX improvements:
* automatic Home Assistant authorization (by @thetic and with additional minor fixes by me)
* most of the configuration is now truly optional - it was anyway, but HASS was marking the fields as `required` which is slightly disorienting for a newcomer
* `asoundrc` field is now an array (passing a multi-line file where whitespace matters into a single-line text field was finicky at best, as discussed [here](https://community.rhasspy.org/t/hass-io-addon-make-rhasspy-use-custom-asound-conf/106/16)) **Note: this could be a breaking change**
* configuration options now have descriptions (in English; I'm not sure if HASS will default to these for other languages)

Note: I've marked this as a draft as I'm yet to build, deploy and fully test these changes (any tips on how to quickly deploy it in a VM or something like that?).
However, comments and thoughts are welcome, so if e.g. splitting this PR into smaller, feature-isolated ones would be preferable I'll gladly do that.