### PR TITLE
Fix link to samples

### DIFF
--- a/voice-nl-rdh/README.md
+++ b/voice-nl-rdh/README.md
@@ -2,7 +2,7 @@
 
 Voice and vocoder models for [larynx](https://github.com/rhasspy/larynx) based on the free [rdh dataset](https://github.com/r-dh/dutch-vl-tts).
 
-[Samples](samples)
+[Samples](https://github.com/rhasspy/nl_larynx-rdh/tree/master/samples)
 
 ## Usage
 


### PR DESCRIPTION
The current link to samples is relative and points to part of the code that is not included in the hassio-addon. This leads to a HTTP 404 error.

This change links to the absolute URL for the examples.