### PR TITLE
Port added to Options and passed on to homeassistant_satellite

### DIFF
--- a/assist_microphone/config.yaml
+++ b/assist_microphone/config.yaml
@@ -11,6 +11,7 @@ map:
   - share:rw
 options:
   token: null
+  port: 8123
   vad: "disabled"
   volume: 1.0
   awake_sound: "/usr/src/sounds/awake.wav"

--- a/assist_microphone/rootfs/etc/s6-overlay/s6-rc.d/assist_microphone/run
+++ b/assist_microphone/rootfs/etc/s6-overlay/s6-rc.d/assist_microphone/run
@@ -16,6 +16,7 @@ fi
 
 exec python3 -m homeassistant_satellite \
     --host 'homeassistant' \
+    --port "$(bashio::config 'port')" \
     --token "$(bashio::config 'token')" \
     --volume "$(bashio::config 'volume')" \
     --awake-sound "$(bashio::config 'awake_sound')" \


### PR DESCRIPTION
When HomeAssistant in ran on non default port 8123, Assist Microphone fails to start. 

This will allow option 'port' to be configured and passed on as argument to `homeassistant_satellite`

Should fix  #25 


Please note I am not able to test this change and I did not update the version either. ... Fix seams as simple as this. 
