### PR TITLE
french : restoring necessary expansion rule - quel

### DIFF
--- a/rhasspy-speech/src/wyoming_rhasspy_speech/sentences/fr.yaml
+++ b/rhasspy-speech/src/wyoming_rhasspy_speech/sentences/fr.yaml
@@ -55,6 +55,7 @@ expansion_rules:
   dans: "(dans|du|de|des|à|au|aux|sur)"
   de: "(du|de|des)"
   tous: "(tout|tous|toute[s])"
+  quel: "quel[le][s]"
 
   # Verbs
   active: "(active|activer|démarre|démarrer|<allume>)"


### PR DESCRIPTION
French language training is broken inside rhasspy-speech
Error : `Missing expansion rule <quel>`

Restoring the mentionned expansion rule _(quel)_, used in HassGetState intent, fixes the issue.