### PR TITLE
Remove `<quel>` expansion rule

### DIFF
--- a/rhasspy-speech/src/wyoming_rhasspy_speech/sentences/fr.yaml
+++ b/rhasspy-speech/src/wyoming_rhasspy_speech/sentences/fr.yaml
@@ -452,7 +452,7 @@ intents:
   HassGetState:
     data:
       - sentences:
-          - "<quel> est [(l'état|le statut|la valeur) de] [<le>]{name} [<dans> [<le>]{area}]"
+          - "quel est [(l'état|le statut|la valeur) de] [<le>]{name} [<dans> [<le>]{area}]"
         requires_context:
           domain:
             - sensor


### PR DESCRIPTION
I forgot one expansion rule when I initially created the sentence set for French