### PR TITLE
stt_fallback: Fail if no valid STT entities found.

### DIFF
--- a/stt-fallback/src/stt_fallback.py
+++ b/stt-fallback/src/stt_fallback.py
@@ -149,15 +149,18 @@ async def main() -> None:
 
     _LOGGER.debug("Entities: %s", entities)
 
-    server = AsyncServer.from_uri(args.uri)
-    _LOGGER.info("Ready")
+    if entities:
+        server = AsyncServer.from_uri(args.uri)
+        _LOGGER.info("Ready")
 
-    try:
-        await server.run(
-            partial(FallbackEventHandler, entities, args.hass_token, args.hass_http_uri)
-        )
-    except KeyboardInterrupt:
-        pass
+        try:
+            await server.run(
+                partial(FallbackEventHandler, entities, args.hass_token, args.hass_http_uri)
+            )
+        except KeyboardInterrupt:
+            pass
+    else:
+        _LOGGER.critical("No valid STT entities found")
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
If none of the provided STT entities are valid, log a critical error and exit.

Useful if you specify invalid entities (e.g. typos) or if STT integration has not yet been properly initialized in HASS.